### PR TITLE
Update Sub.start and start_link to use binary strings

### DIFF
--- a/lib/exredis/sub.ex
+++ b/lib/exredis/sub.ex
@@ -18,27 +18,27 @@ defmodule Exredis.Sub do
   Connect to the Redis server for subscribe to a channel
 
   * `start_link`
-  * `start_link('127.0.0.1', 6379)`
-  * `start_link('127.0.0.1', 6379, 'with_password')`
+  * `start_link("127.0.0.1", 6379)`
+  * `start_link("127.0.0.1", 6379, "with_password")`
   """
-  @spec start_link(list, integer, list, reconnect, max_queue, behaviour) :: start_link
-  def start_link(host \\ '127.0.0.1', port \\ 6379, password \\ '',
+  @spec start_link(binary, integer, binary, reconnect, max_queue, behaviour) :: start_link
+  def start_link(host \\ "127.0.0.1", port \\ 6379, password \\ "",
             reconnect \\ :no_reconnect, max_queue \\ :infinity,
             behaviour \\ :drop), do:
-    :eredis_sub.start_link(host, port, password, reconnect, max_queue, behaviour)
+    :eredis_sub.start_link(String.to_char_list(host), port, String.to_char_list(password), reconnect, max_queue, behaviour)
 
   @doc """
   Connect to the Redis server for subscribe to a channel
 
   * `start`
-  * `start('127.0.0.1', 6379)`
-  * `start('127.0.0.1', 6379, 'with_password')`
+  * `start("127.0.0.1", 6379)`
+  * `start("127.0.0.1", 6379, "with_password")`
   """
   @spec start(list, integer, list, reconnect, max_queue, behaviour) :: pid
-  def start(host \\ '127.0.0.1', port \\ 6379, password \\ '',
+  def start(host \\ "127.0.0.1", port \\ 6379, password \\ "",
             reconnect \\ :no_reconnect, max_queue \\ :infinity,
             behaviour \\ :drop), do:
-    :eredis_sub.start_link(host, port, password, reconnect, max_queue, behaviour)
+    start_link(host, port, password, reconnect, max_queue, behaviour)
     |> elem 1
 
   @doc """


### PR DESCRIPTION
0283124e044f12419f61c572eed78c5a61bb6ca9 switched over the main Exredis.start
and start_link to use binary instead of char lists, but didn't update the Sub
module.
